### PR TITLE
Supporting typescript by adding type definition.

### DIFF
--- a/dist/react-imagebox.d.ts
+++ b/dist/react-imagebox.d.ts
@@ -1,0 +1,53 @@
+import * as React from "react";
+export interface TitleBarConfig {
+    enable?: boolean;
+    className?: string;
+    text?: string;
+    closeButton?: boolean;
+    closeButtonClassName?: string;
+    closeText?: string;
+    position?: string;
+    nextText?: string;
+    prevText?: string;
+}
+
+export interface LightboxConfig {
+    speed?: number;
+    smoothResize?: boolean;
+    fadeMode?: boolean;
+    fadeSpeed?: number;
+    loop?: boolean;
+    clickSwitch?: boolean;
+    compatible?: boolean;
+    maxHeight?: number;
+    maxWidth?: number;
+    minHeight?: number;
+    minWidth?: number;
+    initHeight?: number;
+    initWidth?: number;
+}
+
+export interface Config {
+    className?: string;
+    overlayOpacity?: number;
+    fadeIn?: boolean;
+    fadeInSpeed?: number;
+    fadeOut?: boolean;
+    fadeOutSpeed?: number;
+    titleBar?: TitleBarConfig;
+    lightbox?: LightboxConfig;
+    onOpen?: () => void;
+    onComplete?: () => void;
+    onCleanup?: () => void;
+    onClosed?: () => void;
+}
+
+export class Imagebox extends React.Component<Config, {}> {
+    openImagebox(): void;
+    closeImagebox(): void;
+}
+
+export class ImageboxTrigger extends React.Component<{}, {}> {
+}
+export class ImageboxModal extends React.Component<{}, {}> {
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.3",
   "description": "A simple image lightbox component for react",
   "main": "dist/react-imagebox.js",
+  "typings": "dist/react-imagebox.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Fraina/react-imagebox.git"


### PR DESCRIPTION
This should enable people using `react-imagebox` in typescript.

Usage:

```
import * as React from "react";
import { Imagebox, ImageboxTrigger, ImageboxModal } from "react-imagebox";

export default class App extends React.Component<{}, {}> {
    render() {
        return (
            <Imagebox ref="Imagebox">
                <ImageboxTrigger>
                    <button>Click me</button>
                </ImageboxTrigger>
                <ImageboxModal>
                    <ul>
                        <li data-title="pic title">
                            <img data-src="static/william-blake.jpg" />
                        </li>
                        <li data-title="pic title">
                            <img data-src="static/beatles.jpg" />
                        </li>
                        <li data-title="pic title">
                            <img data-src="static/THE_PROPERTY_OF_JENS_BERGE.jpg" />
                        </li>
                    </ul>
                </ImageboxModal>
            </Imagebox>
        );
    }
}
```
